### PR TITLE
feat: Remove used client_id from wake_up_sender hashmap

### DIFF
--- a/server/src/web/routes_auth.rs
+++ b/server/src/web/routes_auth.rs
@@ -23,10 +23,7 @@ pub fn routes(mc: ModelController) -> Router {
 }
 
 async fn info(State(mc): State<ModelController>) -> MyResult<String> {
-    let clients = mc
-        .connected_clients
-        .lock()
-        .await;
+    let clients = mc.wake_up_sender.lock().await;
     Ok(format!("{:#?}", clients))
 }
 

--- a/server/src/web/routes_wake_up.rs
+++ b/server/src/web/routes_wake_up.rs
@@ -46,5 +46,10 @@ async fn wake_up(
         }
     };
 
+    // We get the wake_up_sender from our state and remove the already used client id
+    // from the hashmap
+    let mut wake_up_sender = mc.wake_up_sender.lock().await;
+    wake_up_sender.remove(&user_id);
+
     Ok(Protobuf(result))
 }


### PR DESCRIPTION
Remove the already used client_id sender combination from the wake_up_sender hashmap.